### PR TITLE
GitHub release stats

### DIFF
--- a/example/github-interface-cli.js
+++ b/example/github-interface-cli.js
@@ -11,7 +11,7 @@ const {prerelease} = require('../lib/github-interface')
 const argv = require('minimist')(process.argv.slice(2))
 
 function usage () {
-  console.log(`USAGE: node github-interface.js --repo org/repo --version v2.0.0 --message 'Best releae ever'`)
+  console.log(`USAGE: node example/github-interface-cli.js --repo org/repo --version v2.0.0 --message 'Best release ever'`)
 }
 
 const { repo, version, message } = argv

--- a/example/github-prerelease-cli.js
+++ b/example/github-prerelease-cli.js
@@ -1,17 +1,17 @@
 /*
-github-interface-cli
+github-prerelease-cli
 
 Make sure you've got a github.rc in the project root with your username and an api key.
 
 USAGE:
-  node example/github-interface-cli.js --repo olizilla/tags --version v2.0.0 --message "good one"
+  node example/github-prerelease-cli.js --repo olizilla/tags --version v2.0.0 --message "good one"
 
 */
 const {prerelease} = require('../lib/github-interface')
 const argv = require('minimist')(process.argv.slice(2))
 
 function usage () {
-  console.log(`USAGE: node example/github-interface-cli.js --repo org/repo --version v2.0.0 --message 'Best release ever'`)
+  console.log(`USAGE: node example/github-prerelease-cli.js --repo org/repo --version v2.0.0 --message 'Best release ever'`)
 }
 
 const { repo, version, message } = argv

--- a/example/github-release-stats-cli.js
+++ b/example/github-release-stats-cli.js
@@ -1,7 +1,7 @@
 /*
 github-release-stats-cli
 
-Make sure you've got a github.rc in the project root with your username and an api key.
+Make sure you've got a .githubrc in the project root with your username and an personal access token.
 
 USAGE:
   node example/github-release-stats-cli.js --repo olizilla/tags --version v2.0.0

--- a/example/github-release-stats-cli.js
+++ b/example/github-release-stats-cli.js
@@ -1,0 +1,35 @@
+/*
+github-release-stats-cli
+
+Make sure you've got a github.rc in the project root with your username and an api key.
+
+USAGE:
+  node example/github-release-stats-cli.js --repo olizilla/tags --version v2.0.0
+
+*/
+const {releaseStats} = require('../lib/github-interface')
+const argv = require('minimist')(process.argv.slice(2))
+
+function usage () {
+  console.log(`USAGE: node example/github-release-stats-cli.js --repo org/repo --version v2.0.0`)
+}
+
+const { repo, version } = argv
+if (!repo || !version) {
+  usage()
+  process.exit(-1)
+}
+
+let repos = repo
+if (!Array.isArray(repos)) {
+  repos = [repo]
+}
+
+releaseStats({repos, version})
+  .then(({ commits, additions, deletions }) => {
+    console.log(`This release saw ${commits} commits, with ${additions} lines of code added and ${deletions} removed across all the supplied repos`)
+  })
+  .catch((err) => {
+    console.error(err)
+    process.exit(-1)
+  })

--- a/lib/github-interface.js
+++ b/lib/github-interface.js
@@ -27,10 +27,19 @@ async function prerelease ({ repos, version, message }) {
   return prereleaseRepo({ repo: repos[0], version, message })
 }
 
+async function releaseStats ({ repos, version }) {
+
+}
+
+function getReleases ({ repo }) {
+
+}
+
 async function tagRepo ({ repo, version }) {
   const lastCommit = await request({
     method: 'GET',
     url: `${githubApiBase}/repos/${repo}/commits/master`,
+    auth,
     json: true,
     headers: githubHeaders
   })

--- a/lib/github-interface.js
+++ b/lib/github-interface.js
@@ -12,10 +12,116 @@ const githubHeaders = {
   'User-Agent': 'tableflip-adventure'
 }
 
+// Aggregates stats for the given release of the supplied repos.
+// Returns a promise which resolves to an object of the form:
+//
+// {
+//   commits: 100,
+//   additions: 1234,
+//   deletions: 123
+// }
+//
+// For example:
+//
+// releaseStats({
+//   repos: ['tableflip/project-frontend', 'tableflip/project-api'],
+//   version: 'v2.0.0'
+// })
+function releaseStats ({ repos, version }) {
+  const stats = repos.map((repo) => repoReleaseStats({ repo, version }))
+  return Promise.all(stats)
+    .then((reposData) => {
+      return reposData.reduce((memo, repoData) => {
+        return {
+          commits: memo.commits + repoData.commits,
+          additions: memo.additions + repoData.additions,
+          deletions: memo.deletions + repoData.deletions
+        }
+      }, { commits: 0, additions: 0, deletions: 0 })
+    })
+}
+
+// Gets the aggregate stats for the given repo and version, by comparing it to the previous tagged version if available,
+// or summarising the whole history if not
+async function repoReleaseStats ({ repo, version }) {
+  const releaseTags = await getTags({ repo })
+  const tagIndex = releaseTags.indexOf(version)
+
+  if (tagIndex === -1) throw new Error(`There is no release tagged ${version}`)
+
+  const previousVersion = releaseTags[tagIndex + 1]
+
+  if (previousVersion) {
+    return getCommitComparison({ repo, lastCommit: version, firstCommit: previousVersion })
+  } else {
+    return getRepoStats({ repo })
+  }
+}
+
+// Gets aggregate comparison stats between the two supplied commits (which could be branches or tags)
+async function getCommitComparison ({ repo, firstCommit, lastCommit }) {
+  const stats = await request({
+    method: 'GET',
+    url: `${githubApiBase}/repos/${repo}/compare/${firstCommit}...${lastCommit}`,
+    auth,
+    json: true,
+    headers: githubHeaders
+  })
+
+  const lineStats = stats.files.reduce((memo, file) => {
+    return {
+      additions: memo.additions + file.additions,
+      deletions: memo.deletions + file.deletions
+    }
+  }, { additions: 0, deletions: 0 })
+
+  return {
+    commits: stats.commits.length,
+    additions: lineStats.additions,
+    deletions: lineStats.deletions
+  }
+}
+
+// Gets aggregate stats for the full history of a repo - this is used if there was no previous tag to compare against
+async function getRepoStats ({ repo }) {
+  const stats = await request({
+    method: 'GET',
+    url: `${githubApiBase}/repos/${repo}/stats/contributors`,
+    auth,
+    json: true,
+    headers: githubHeaders
+  })
+
+  if (!stats || !stats.length) throw new Error(`Cannot get stats for ${repo}`)
+
+  return stats[0].weeks.reduce((memo, week) => {
+    return {
+      commits: memo.commits + week.c,
+      additions: memo.additions + week.a,
+      deletions: memo.deletions + week.d
+    }
+  }, { commits: 0, additions: 0, deletions: 0 })
+}
+
+// Returns a repo's tags in reverse chronological order
+async function getTags ({ repo }) {
+  const tags = await request({
+    method: 'GET',
+    url: `${githubApiBase}/repos/${repo}/tags`,
+    auth,
+    json: true,
+    headers: githubHeaders
+  })
+
+  return tags.map((tag) => tag.name)
+}
+
 // Adds the given version number as a tag to all of the supplied repos and a prerelease
 // with the supplied message to the first repo in the array.
 // Returns a promise that resolves to the Github API release-creation response
+//
 // For example:
+//
 // prerelease({
 //   repos: ['tableflip/project-frontend', 'tableflip/project-api'],
 //   version: 'v2.0.0',
@@ -27,14 +133,7 @@ async function prerelease ({ repos, version, message }) {
   return prereleaseRepo({ repo: repos[0], version, message })
 }
 
-async function releaseStats ({ repos, version }) {
-
-}
-
-function getReleases ({ repo }) {
-
-}
-
+// Adds a the supplied version tag to the current master branch in the given repo
 async function tagRepo ({ repo, version }) {
   const lastCommit = await request({
     method: 'GET',
@@ -58,6 +157,7 @@ async function tagRepo ({ repo, version }) {
   })
 }
 
+// Adds a release (with the prerelease flag) to the supplied version, with the supplied message, to the given repo
 function prereleaseRepo ({ repo, version, message }) {
   return request({
     method: 'POST',
@@ -75,5 +175,6 @@ function prereleaseRepo ({ repo, version, message }) {
 }
 
 module.exports = {
-  prerelease
+  prerelease,
+  releaseStats
 }


### PR DESCRIPTION
Adds function to calculate aggregate stats (number of commits, lines added, lines removed) for the supplied repos and a given version number.

Stats are calculated on the basis of comparison to the previous version, or else the whole commit history if this is the first tag.

Also adds a CLI example, which can be run with:

```sh
> node example/github-release-stats-cli.js --repo olizilla/tags --version v2.0.0
```